### PR TITLE
Add _ssid API and name to WiFi page

### DIFF
--- a/multi_ear_services/ctrl/__init__.py
+++ b/multi_ear_services/ctrl/__init__.py
@@ -138,6 +138,11 @@ def create_app(test_config=None):
         resp = utils.wlan_autohotspot()
         return jsonify(resp), 200
 
+    @app.route("/_ssid", methods=['GET'])
+    def ssid_api():
+        ssid = os.popen("sudo iwgetid -r").read().rstrip("\n")
+        return jsonify({"ssid": ssid}), 200
+
     @app.route("/_storage", methods=['GET'])
     def storage_api():
         if not is_rpi:

--- a/multi_ear_services/ctrl/static/js/multi-ear.js
+++ b/multi_ear_services/ctrl/static/js/multi-ear.js
@@ -672,6 +672,13 @@ async function resizePCB () {
 
 }
 
+function loadConnectedSSID() {
+
+    getResponse('/_ssid').then(function(resp) {
+        document.getElementById("ssid-connected").innerHTML = `Connected to <b>${JSON.parse(resp.response).ssid}</b>`
+    });
+
+}
 
 function loadContent(nav) {
 
@@ -711,6 +718,7 @@ function loadContent(nav) {
                     break;
 
                 case "wifi":
+		    loadConnectedSSID()
                     showPasswordToggle()
                     validateWifiForm()
                     break;

--- a/multi_ear_services/ctrl/templates/tabs/wifi.html.jinja
+++ b/multi_ear_services/ctrl/templates/tabs/wifi.html.jinja
@@ -42,6 +42,8 @@
 
   <h3 class="mb-3 hstack gap-3">Client mode <div class="vr"></div> <small class="text-muted">join a known wireless network</small></h3>
 
+  <h6><span id="ssid-connected" class="badge bg-success"></span></h6>
+
   <p>Enter the <code>name</code> and <code>passphrase</code> to add a wireless network to the Multi-EAR. 
      The passphrase will be encrypted.<br> 
      Only visible and WPA2 (WPA Personal) secured networks are supported.


### PR DESCRIPTION
- Add API route `/_ssid` to obtain the current SSID for display.
- Added JS/HTML to display on the WiFi tab.

Eventually it would be nice to manage (forget) existing configured connections.